### PR TITLE
WiiFlow compatibility for autolauch games. (FIX94)

### DIFF
--- a/main/main_gc-menu2.cpp
+++ b/main/main_gc-menu2.cpp
@@ -366,8 +366,6 @@ int main(int argc, char* argv[]) {
 	
 	if (menu->Autoboot)
 	{
-		// after init wpad wait a bit
-		sleep(2);
 		menu->setActiveFrame(MenuContext::FRAME_LOADROM);
 		menu->Autoboot = false;
 	}

--- a/menu/FileBrowserFrame.cpp
+++ b/menu/FileBrowserFrame.cpp
@@ -472,7 +472,7 @@ void fileBrowserFrame_LoadFile(int i)
 		// We must select this file
 		int ret = loadROM( &dir_entries[i] );
 		
-		if(!ret){	// If the read succeeded.
+		if(!ret && !pMenuContext->Autoboot){	// If the read succeeded.
 			strcpy(feedback_string, "Loaded ");
 			strncat(feedback_string, filenameFromAbsPath(dir_entries[i].name), 36-7);
 
@@ -513,7 +513,7 @@ void fileBrowserFrame_LoadFile(int i)
 
 			menu::MessageBox::getInstance().setMessage(RomInfo);
 		}
-		else		// If not.
+		else if(ret)		// If not.
 		{
   		switch(ret) {
     		case ROM_CACHE_ERROR_READ:
@@ -561,4 +561,14 @@ void fileBrowserFrame_LoadFile(int i)
 		pMenuContext->setActiveFrame(MenuContext::FRAME_MAIN);
 		if(hasLoadedROM) Func_SetPlayGame();
 	}
+}
+
+
+void fileBrowserFrame_AutoBootFile()
+{
+	int i;
+	for(i = 0; i < num_entries - 1; i++)
+		if(strcasestr(dir_entries[i].name, pMenuContext->AutobootROM) != NULL)
+			break;
+	fileBrowserFrame_LoadFile(i);
 }

--- a/menu/FileBrowserFrame.h
+++ b/menu/FileBrowserFrame.h
@@ -39,4 +39,6 @@ private:
 #endif
 };
 
+void fileBrowserFrame_AutoBootFile();
+
 #endif

--- a/menu/LoadRomFrame.cpp
+++ b/menu/LoadRomFrame.cpp
@@ -128,7 +128,15 @@ void Func_LoadFromSD()
 	romFile_init( romFile_topLevel );
 
 	pMenuContext->setActiveFrame(MenuContext::FRAME_FILEBROWSER);
-	fileBrowserFrame_OpenDirectory(romFile_topLevel);
+	
+	if(pMenuContext->Autoboot)
+	{
+		strncpy(romFile_topLevel->name, pMenuContext->AutobootPath, sizeof(romFile_topLevel->name));
+		fileBrowserFrame_OpenDirectory(romFile_topLevel);
+		fileBrowserFrame_AutoBootFile();
+	}
+	else
+		fileBrowserFrame_OpenDirectory(romFile_topLevel);
 }
 
 void Func_LoadFromDVD()
@@ -146,7 +154,15 @@ void Func_LoadFromDVD()
 	romFile_init( romFile_topLevel );
 
 	pMenuContext->setActiveFrame(MenuContext::FRAME_FILEBROWSER);
-	fileBrowserFrame_OpenDirectory(romFile_topLevel);
+	
+	if(pMenuContext->Autoboot)
+	{
+		strncpy(romFile_topLevel->name, pMenuContext->AutobootPath, sizeof(romFile_topLevel->name));
+		fileBrowserFrame_OpenDirectory(romFile_topLevel);
+		fileBrowserFrame_AutoBootFile();
+	}
+	else
+		fileBrowserFrame_OpenDirectory(romFile_topLevel);
 }
 
 void Func_LoadFromUSB()
@@ -166,7 +182,15 @@ void Func_LoadFromUSB()
 	romFile_init( romFile_topLevel );
 	
 	pMenuContext->setActiveFrame(MenuContext::FRAME_FILEBROWSER);
-	fileBrowserFrame_OpenDirectory(romFile_topLevel);
+	
+	if(pMenuContext->Autoboot)
+	{
+		strncpy(romFile_topLevel->name, pMenuContext->AutobootPath, sizeof(romFile_topLevel->name));
+		fileBrowserFrame_OpenDirectory(romFile_topLevel);
+		fileBrowserFrame_AutoBootFile();
+	}
+	else
+		fileBrowserFrame_OpenDirectory(romFile_topLevel);
 #endif
 }
 

--- a/menu/LoadRomFrame.h
+++ b/menu/LoadRomFrame.h
@@ -34,4 +34,7 @@ private:
 	
 };
 
+void Func_LoadFromSD();
+void Func_LoadFromUSB();
+
 #endif

--- a/menu/MainFrame.cpp
+++ b/menu/MainFrame.cpp
@@ -350,6 +350,8 @@ void Func_PlayGame()
 void Func_SetPlayGame()
 {
 	FRAME_BUTTONS[5].buttonString = FRAME_STRINGS[5];
+	if(pMenuContext->Autoboot)
+		Func_PlayGame();
 }
 
 void Func_SetResumeGame()

--- a/menu/MenuContext.cpp
+++ b/menu/MenuContext.cpp
@@ -79,6 +79,8 @@ MenuContext::MenuContext(GXRModeObj *vmode)
 	menu::Gui::getInstance().addFrame(configurePaksFrame);
 	menu::Gui::getInstance().addFrame(configureButtonsFrame);
 
+	Autoboot = false;
+			  
 	menu::Focus::getInstance().setFocusActive(true);
 	setActiveFrame(FRAME_MAIN);
 }
@@ -174,6 +176,13 @@ void MenuContext::setActiveFrame(int frameIndex)
 
 	if(currentActiveFrame)
 	{
+		if(currentActiveFrame == loadRomFrame && Autoboot)
+		{
+			if(strcasestr(AutobootPath,"sd:/") != NULL)
+				Func_LoadFromSD();
+			else
+				Func_LoadFromUSB();
+		}
 		currentActiveFrame->showFrame();
 		menu::Focus::getInstance().setCurrentFrame(currentActiveFrame);
 		menu::Cursor::getInstance().setCurrentFrame(currentActiveFrame);

--- a/menu/MenuContext.h
+++ b/menu/MenuContext.h
@@ -46,6 +46,9 @@ public:
 	MenuContext(GXRModeObj *vmode);
 	~MenuContext();
 	bool isRunning();
+	bool Autoboot;
+	char AutobootROM[1024];
+	char AutobootPath[1024];
 	void setUseMiniMenu(bool setUseMiniMenu);
 	void setActiveFrame(int frameIndex);
 	void setActiveFrame(int frameIndex, int submenu);


### PR DESCRIPTION
From http://github.com/FIX94/Wii64

Adds arguments support for autolaunch games via WiiFlow.

In the meta.xml file, the arguments for use are:
`<arguments>`
`<arg>{device}:/{path_of_ROM}</arg>`
`<arg>{ROM_file}</arg>`
`</arguments>`

For example:
`<arguments>`
`<arg>sd:/apps/wii64_singlegame/rom</arg>`
`<arg>SuperMario64.z64</arg>`
`</arguments>`

This will be useful for WiiFlow, and other game launchers including making custom simple game loaders along with forwarder channels, specially since Wii64 is the only N64 emulator for Wii which has Rice GFX for that problematic games that wouldn't run in glN64 GFX.
Also I added a small change which allows the user to change the ROM even after using autoboot.

This code i'm adding will not interfiere with other arguments that can be used also in meta.xml (such CountPerOp, FBTex, ScreenMode, etc.)

Thanks! @saulfabregwiivc