### PR TITLE
Add HOME as an option to return to the menu for Wii U GamePad and set it as default

### DIFF
--- a/gc_input/controller-DRC.c
+++ b/gc_input/controller-DRC.c
@@ -96,6 +96,7 @@ static button_t analog_sources[] = {
 static button_t menu_combos[] = {
 	{ 0, WIIDRC_BUTTON_X|WIIDRC_BUTTON_Y, "X+Y" },
 	{ 1, WIIDRC_BUTTON_ZL|WIIDRC_BUTTON_ZR, "ZL+ZR" },
+	{ 2, WIIDRC_BUTTON_HOME, "Home" },
 };
 
 static unsigned int getButtons()
@@ -223,7 +224,7 @@ controller_t controller_DRC =
 	    .CR        = &buttons[18], // Right Stick Right
 	    .CD        = &buttons[19], // Right Stick Down
 	    .analog    = &analog_sources[0],
-	    .exit      = &menu_combos[0],
+	    .exit      = &menu_combos[2],
 	    .invertedY = 0,
 	  }
 	 };


### PR DESCRIPTION
Until now, the Wii U GamePad can't return to the emulator menu using the GamePad's HOME button.
This adds said button for be able to return to the menu.

Also makes the default button for return to the emulator menu when using Wii U GamePad (DRC) as controller.