### PR TITLE
RiceVideoLinux: more settings for Doom 64, Killer Instinct Gold and other games in Rice GFX

### DIFF
--- a/release/wii64/.gitattributes
+++ b/release/wii64/.gitattributes
@@ -1,0 +1,1 @@
+text=auto

--- a/release/wii64/.gitattributes
+++ b/release/wii64/.gitattributes
@@ -1,1 +1,2 @@
-text=auto
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/release/wii64/RiceVideoLinux.ini
+++ b/release/wii64/RiceVideoLinux.ini
@@ -507,6 +507,12 @@ NormalAlphaBlender=1
 NormalColorCombiner=1
 RenderToTexture=2
 
+{e311d4f9c09bb27c-45}
+Name=EXCITEBIKE64
+NormalAlphaBlender=1
+NormalColorCombiner=1
+RenderToTexture=2
+
 {0b15d45cf1c20c47-45}
 Name=Extreme G 2
 PrimaryDepthHack
@@ -768,7 +774,22 @@ AlternativeTxtSizeMethod=1
 FrameBufferEmulation=2
 RenderToTexture=3
 
+{59825e661dbd98d0-4a}
+Name=POKEMON STADIUM
+FrameBufferEmulation=3
+RenderToTexture=3
+
 {b3d9f590f0dc0e9d-45}
+Name=POKEMON STADIUM
+FrameBufferEmulation=3
+RenderToTexture=3
+
+{432d121a0faf7dc1-45}
+Name=POKEMON STADIUM
+FrameBufferEmulation=3
+RenderToTexture=3
+
+{fab28f9c9ba0849b-45}
 Name=POKEMON STADIUM
 FrameBufferEmulation=3
 RenderToTexture=3

--- a/release/wii64/RiceVideoLinux.ini
+++ b/release/wii64/RiceVideoLinux.ini
@@ -457,6 +457,26 @@ Name=DONKEY KONG 64
 NormalColorCombiner=1
 EmulateClear=1
 
+{1a103ea89db637e9-45}
+Name=Doom64
+ForceScreenClear=1
+
+{f4963e425bf088ce-45}
+Name=Doom64
+ForceScreenClear=1
+
+{365ba67aade5cefd-4a}
+Name=DOOM64
+ForceScreenClear=1
+
+{ac9e732c2677f79e-50}
+Name=Doom64
+ForceScreenClear=1
+
+{af45dd04b7fd9526-45}
+Name=DOOM 64
+ForceScreenClear=1
+
 {134d9d76fe3f23da-45}
 Name=DR.MARIO 64
 FastTextureCRC=2
@@ -562,6 +582,10 @@ NormalAlphaBlender=1
 NormalColorCombiner=1
 FrameBufferEmulation=4
 RenderToTexture=5
+
+{facd8f9e2b65f549-45}
+Name=KILLER INSTINCT GOLD
+ForceScreenClear=1
 
 {4cca08f927434636-45}
 Name=Killer Instinct Gold

--- a/release/wii64/RiceVideoLinux.ini
+++ b/release/wii64/RiceVideoLinux.ini
@@ -776,7 +776,6 @@ RenderToTexture=3
 
 {59825e661dbd98d0-4a}
 Name=POKEMON STADIUM
-AccurateTextureMapping=1
 FrameBufferEmulation=3
 RenderToTexture=3
 
@@ -964,13 +963,14 @@ VIHeight=480
 {fbfb8406a5a83e5d-45}
 Name=STARCRAFT 64
 NormalAlphaBlender=2
-UseCIWidthAndRatio=1
+ForceScreenClear=1
 RenderToTexture=3
 
 {a35ecf42df34139a-50}
 Name=STARCRAFT 64
 NormalAlphaBlender=2
 UseCIWidthAndRatio=1
+ForceScreenClear=1
 RenderToTexture=3
 
 {a00b78ba34db210f-45}
@@ -1325,7 +1325,6 @@ ForceScreenClear=1
 
 {a2dc9ac4621b50f1-45}
 Name=GT64
-IncTexRectEdge
 ScreenUpdateSetting=4
 
 {e07359beb8edb089-45}
@@ -1335,4 +1334,10 @@ Name=TOP GEAR RALLY 2
 Name=TOP GEAR RALLY
 ForceScreenClear=1
 ScreenUpdateSetting=2
+
+{274ec1cb9a505745-45}
+Name=Resident Evil II
+
+{7e260025cec37e2a-45}
+Name=RIDGE RACER 64
 

--- a/release/wii64/RiceVideoLinux.ini
+++ b/release/wii64/RiceVideoLinux.ini
@@ -506,12 +506,14 @@ Name=EXCITEBIKE64
 NormalAlphaBlender=1
 NormalColorCombiner=1
 RenderToTexture=2
+ScreenUpdateSetting=1
 
 {e311d4f9c09bb27c-45}
 Name=EXCITEBIKE64
 NormalAlphaBlender=1
 NormalColorCombiner=1
 RenderToTexture=2
+ScreenUpdateSetting=1
 
 {0b15d45cf1c20c47-45}
 Name=Extreme G 2
@@ -776,6 +778,7 @@ RenderToTexture=3
 
 {59825e661dbd98d0-4a}
 Name=POKEMON STADIUM
+AccurateTextureMapping=1
 FrameBufferEmulation=3
 RenderToTexture=3
 
@@ -892,9 +895,9 @@ Name=Shadow of the Empire
 AccurateTextureMapping=2
 NormalAlphaBlender=1
 NormalColorCombiner=1
+DisableObjBG=1
 FrameBufferEmulation=3
 RenderToTexture=2
-DisableObjBG=1
 ScreenUpdateSetting=4
 
 {8166484d45927dab-50}
@@ -902,9 +905,9 @@ Name=Shadow of the Empire
 AccurateTextureMapping=2
 NormalAlphaBlender=1
 NormalColorCombiner=1
+DisableObjBG=1
 FrameBufferEmulation=3
 RenderToTexture=2
-DisableObjBG=1
 ScreenUpdateSetting=4
 
 {5c7e4d2622468718-45}
@@ -912,9 +915,9 @@ Name=Shadow of the Empire
 AccurateTextureMapping=2
 NormalAlphaBlender=1
 NormalColorCombiner=1
+DisableObjBG=1
 FrameBufferEmulation=3
 RenderToTexture=2
-DisableObjBG=1
 ScreenUpdateSetting=4
 
 {91b0474160102563-45}
@@ -922,9 +925,9 @@ Name=Shadow of the Empire
 AccurateTextureMapping=2
 NormalAlphaBlender=1
 NormalColorCombiner=1
+DisableObjBG=1
 FrameBufferEmulation=3
 RenderToTexture=2
-DisableObjBG=1
 ScreenUpdateSetting=4
 
 {0d7ddff78f0152ed-00}
@@ -1073,9 +1076,9 @@ ScreenUpdateSetting=1
 {6a0571ea474821e4-45}
 Name=VIGILANTE 8
 NormalColorCombiner=1
+FullTMEM=2
 RenderToTexture=4
 ScreenUpdateSetting=4
-FullTMEM=2
 
 {d0f2f9989cf0d903-50}
 Name=Virtual Pool 64
@@ -1218,4 +1221,66 @@ Name=Blast Corps
 
 {a284e5de8711160f-45}
 Name=DESTRUCT DERBY
+
+{79e9ff2ef7df3a02-45}
+Name=MK64 - AMPED UP 2.98
+AccurateTextureMapping=1
+FastTextureCRC=1
+NormalAlphaBlender=1
+NormalColorCombiner=1
+
+{432d121a0faf7dc1-45}
+Name=POKEMON STADIUM
+
+{89d1ff2e5ae59dc2-45}
+Name=MK64 - AMPED UP 2.99
+AccurateTextureMapping=1
+FastTextureCRC=1
+NormalAlphaBlender=1
+NormalColorCombiner=1
+
+{47abd8df89ebdb3c-45}
+Name=J F G DISPLAY
+AccurateTextureMapping=1
+NormalAlphaBlender=1
+NormalColorCombiner=1
+RenderToTexture=3
+
+{efb06a1c397e726b-45}
+Name=MK64 - AMPED UP 2.9A
+AccurateTextureMapping=1
+FastTextureCRC=1
+NormalAlphaBlender=1
+NormalColorCombiner=1
+
+{f799264fd4308262-45}
+Name=OVERKART64 V6 101324
+AccurateTextureMapping=1
+FastTextureCRC=1
+NormalAlphaBlender=1
+NormalColorCombiner=1
+
+{c0ef8cd655d9810b-45}
+Name=SMASH REMIX
+AccurateTextureMapping=1
+NormalAlphaBlender=2
+NormalColorCombiner=1
+PrimaryDepthHack
+ForceScreenClear=1
+
+{cd5cba051e7cb9ab-45}
+Name=SMASH REMIX
+AccurateTextureMapping=1
+NormalAlphaBlender=2
+NormalColorCombiner=1
+PrimaryDepthHack
+ForceScreenClear=1
+
+{70e270fc61a18e65-45}
+Name=Silicon Valley
+AlternativeTxtSizeMethod=1
+RenderToTexture=3
+
+{a51f095afe78aa5a-45}
+Name=Sands of Time
 

--- a/release/wii64/RiceVideoLinux.ini
+++ b/release/wii64/RiceVideoLinux.ini
@@ -202,8 +202,6 @@ NormalColorCombiner=1
 Name=BATTLEZONE
 NormalAlphaBlender=1
 NormalColorCombiner=1
-VIWidth=320
-VIHeight=240
 AlternativeTxtSizeMethod=1
 ScreenUpdateSetting=3
 
@@ -966,7 +964,8 @@ VIHeight=480
 {fbfb8406a5a83e5d-45}
 Name=STARCRAFT 64
 NormalAlphaBlender=2
-RenderToTexture=2
+UseCIWidthAndRatio=1
+RenderToTexture=3
 
 {a35ecf42df34139a-50}
 Name=STARCRAFT 64
@@ -1036,6 +1035,7 @@ ForceScreenClear=1
 
 {3d9b2662e8b111fe-45}
 Name=TOP GEAR RALLY
+ForceScreenClear=1
 ScreenUpdateSetting=2
 
 {a43c70efc99a4a4d-4a}
@@ -1283,4 +1283,56 @@ RenderToTexture=3
 
 {a51f095afe78aa5a-45}
 Name=Sands of Time
+
+{03ef9c7d065b1057-45}
+Name=MK64 - AMPED UP 3.00
+AccurateTextureMapping=1
+FastTextureCRC=1
+NormalAlphaBlender=1
+NormalColorCombiner=1
+
+{171b3d2b1ed80e16-45}
+Name=MK64 - AMPED UP 3.01
+AccurateTextureMapping=1
+FastTextureCRC=1
+NormalAlphaBlender=1
+NormalColorCombiner=1
+
+{994cea65f8c6c22b-45}
+Name=MK64 - AMPED UP 3.02
+AccurateTextureMapping=1
+FastTextureCRC=1
+NormalAlphaBlender=1
+NormalColorCombiner=1
+
+{5cc489e588848b5f-41}
+Name=Portal 64
+
+{99d7e0fc546c3165-45}
+Name=KNIFE EDGE
+
+{a8e43ccb48dbedfc-45}
+Name=Top Gear Hyper Bike
+ScreenUpdateSetting=1
+
+{151db1039185b946-45}
+Name=Top Gear Overdrive
+AccurateTextureMapping=2
+NormalColorCombiner=1
+UseCIWidthAndRatio=1
+AlternativeTxtSizeMethod=1
+ForceScreenClear=1
+
+{a2dc9ac4621b50f1-45}
+Name=GT64
+IncTexRectEdge
+ScreenUpdateSetting=4
+
+{e07359beb8edb089-45}
+Name=TOP GEAR RALLY 2
+
+{01e7437fd1286353-50}
+Name=TOP GEAR RALLY
+ForceScreenClear=1
+ScreenUpdateSetting=2
 


### PR DESCRIPTION
Add settings needed for those games in Rice GFX:
- **Doom 64**: fixes 2D graphics and glitchy white backdrops/2D object glitching on all versions (USA rev0, rev1, Europe, Japan)
- **[Doom 64 XE v1.1 hack](https://github.com/Immorpher/doom64xe/)** (as DOOM 64): same as Doom 64
- **Killer Instinct Gold**: bring same config to USA rev0 like USA rev1 and USA rev2
- **ExciteBike 64**: bring same config to USA rev0 like USA rev1
- **Pocket Monsters Stadium/Pokémon Stadium Zero (JPN)**: use config for Pokémon Stadium 1 USA
- **Pokémon Stadium (USA)**: bring same config to USA rev0 and USA rev1 like USA rev2