### PR TITLE
Fix NTSC color in 240p over composite cables

### DIFF
--- a/libgui/GraphicsGX.cpp
+++ b/libgui/GraphicsGX.cpp
@@ -51,7 +51,7 @@ Graphics::Graphics(GXRModeObj *rmode)
 		memcpy( &vmode_phys, vmode, sizeof(GXRModeObj));
 		break;
 	case VIDEOMODE_240P:
-		vmode = &TVEurgb60Hz240DsAa;
+		vmode = &TVNtsc240DsAa;
 		memcpy( &vmode_phys, vmode, sizeof(GXRModeObj));
 		break;
 	case VIDEOMODE_480P:
@@ -579,7 +579,7 @@ GXRModeObj* Graphics::getVmode() {
 }
 
 void Graphics::setNativeOut(bool is_pal) {
-	GXRModeObj* m = &TVEurgb60Hz240Ds;
+	GXRModeObj* m = &TVNtsc240Ds;
 	if(is_pal) {
 		m = &TVPal264Ds;
 	}


### PR DESCRIPTION
Maybe this should have been an issue?
I noticed after 1.4.1 enabling 240p on my setup would show as grayscale

These changes i made fixed it for me but to be honest I'm not sure if this is the right way to do it or if this causes any issues for anyone else's setups as I only own composite cables and crts